### PR TITLE
Release 0.2.0 version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,5 +2,7 @@
 
 ## Unreleased
 
+## 0.2.0 - (March 21, 2023)
+
 * set up repo and created Terra bundle
 * Set up CI/CD

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cerner/terra-asset-bundle",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "frontend assets for terra",
   "main": "src/index.js",
   "engines": {


### PR DESCRIPTION
This is to test the main branch auto release setup. 

Ran `npm run prepare-for-release` locally which would run the terra pre-release script.