### PR TITLE
Update webpack settings to create main.js and main.css files

### DIFF
--- a/package.json
+++ b/package.json
@@ -141,7 +141,8 @@
     "terra-toggle-section-header": "^2.58.4",
     "terra-toolbar": "^1.29.0",
     "terra-visually-hidden-text": "^2.35.0",
-    "xfc": "^1.11.0"
+    "xfc": "^1.11.0",
+    "mini-css-extract-plugin": "^1.3.1"
   },
   "devDependencies": {
     "@babel/cli": "^7.5.0",

--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "test:jest": "npm run jest:compile"
   },
   "dependencies": {
+    "mini-css-extract-plugin": "^1.3.1",
     "react": "^16.8.5",
     "react-dom": "^16.14.0",
     "react-intl": "^2.9.0",
@@ -143,8 +144,7 @@
     "terra-toggle-section-header": "^2.58.4",
     "terra-toolbar": "^1.29.0",
     "terra-visually-hidden-text": "^2.35.0",
-    "xfc": "^1.11.0",
-    "mini-css-extract-plugin": "^1.3.1"
+    "xfc": "^1.11.0"
   },
   "devDependencies": {
     "@babel/cli": "^7.5.0",
@@ -174,8 +174,8 @@
     "postcss-loader": "^3.0.0",
     "webpack": "^5.28.0",
     "webpack-cli": "^4.10.0",
-    "webpack-merge": "^5.8.0",
-    "webpack-dev-server": "^4.11.1"
+    "webpack-dev-server": "^4.11.1",
+    "webpack-merge": "^5.8.0"
   },
   "homepage": "https://github.com/cerner/terra-asset-bundle#readme",
   "directories": {

--- a/package.json
+++ b/package.json
@@ -32,6 +32,8 @@
     "compile:build": "NODE_ENV=development webpack --mode=development",
     "compile:clean": "rm -rf ./lib",
     "compile:prod": "rm -rf ./lib; NODE_ENV=production webpack --mode=production",
+    "start": "webpack serve",
+    "start:prod": "webpack serve --env=[disableHotReloading] --mode=production",
     "deploy": "npm run compile:prod && gh-pages -d lib",
     "deploy-gh-pages": "gh-pages -d lib",
     "jest": "jest",
@@ -170,9 +172,10 @@
     "jest": "^26.6.3",
     "postcss": "^8.4.18",
     "postcss-loader": "^3.0.0",
-    "webpack": "^4.46.0",
+    "webpack": "^5.28.0",
     "webpack-cli": "^4.10.0",
-    "webpack-merge": "^5.8.0"
+    "webpack-merge": "^5.8.0",
+    "webpack-dev-server": "^4.11.1"
   },
   "homepage": "https://github.com/cerner/terra-asset-bundle#readme",
   "directories": {

--- a/src/index.js
+++ b/src/index.js
@@ -227,4 +227,6 @@ TerraFrontendAssets.TerraClinicalLabelValueView = TerraClinicalLabelValueView;
 TerraFrontendAssets.TerraClinicalOnsetPicker = TerraClinicalOnsetPicker;
 TerraFrontendAssets.TerraClinicalResult = TerraClinicalResult;
 
+window.terra = window.terra || TerraFrontendAssets;
+ 
 export default TerraFrontendAssets;

--- a/src/index.js
+++ b/src/index.js
@@ -228,5 +228,5 @@ TerraFrontendAssets.TerraClinicalOnsetPicker = TerraClinicalOnsetPicker;
 TerraFrontendAssets.TerraClinicalResult = TerraClinicalResult;
 
 window.terra = window.terra || TerraFrontendAssets;
- 
+
 export default TerraFrontendAssets;

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,9 +1,21 @@
 const { merge } = require('webpack-merge');
 const WebpackConfigTerra = require('@cerner/webpack-config-terra');
 const path = require('path');
+var webpack = require('webpack');
+const MiniCssExtractPlugin = require('mini-css-extract-plugin');
 
 const repoConfig = () => ({
   entry: './src/index.js',
+  plugins: [
+    new webpack.optimize.LimitChunkCountPlugin({
+        maxChunks: 1, // disable creating additional chunks
+    }),
+    new MiniCssExtractPlugin({
+      filename: 'main.css',
+      chunkFilename: 'main.css',
+      ignoreOrder: true,
+    }),
+  ],
   output: {
     filename: 'main.js',
     path: path.resolve(__dirname, 'lib'),

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,14 +1,14 @@
 const { merge } = require('webpack-merge');
 const WebpackConfigTerra = require('@cerner/webpack-config-terra');
 const path = require('path');
-var webpack = require('webpack');
+const webpack = require('webpack');
 const MiniCssExtractPlugin = require('mini-css-extract-plugin');
 
 const repoConfig = () => ({
   entry: './src/index.js',
   plugins: [
     new webpack.optimize.LimitChunkCountPlugin({
-        maxChunks: 1, // disable creating additional chunks
+      maxChunks: 1, // disable creating additional chunks
     }),
     new MiniCssExtractPlugin({
       filename: 'main.css',


### PR DESCRIPTION
Update webpack settings to create main.js and main.css files 

Tested through MPagesFusion by consuming the minified main.js and main.css files from the bundle.

TerraButton render:
![image](https://user-images.githubusercontent.com/19804033/231892444-80d55b62-9ced-4325-824c-54cd013f5f34.png)

Consumption code:
![image](https://user-images.githubusercontent.com/19804033/231898925-77d62ba7-4bcd-4ac7-a496-a5015a3fdac8.png)
